### PR TITLE
Added Project Spotify to YtMusic

### DIFF
--- a/Spotify to YtMusic/browser.json
+++ b/Spotify to YtMusic/browser.json
@@ -1,0 +1,13 @@
+{
+    "accept": "*/*",
+    "accept-encoding": "gzip, deflate",
+    "authorization": "your_authorization_token_here",
+    "content-encoding": "gzip",
+    "content-type": "application/json",
+    "cookie": "your_cookie_data_here",
+    "origin": "https://music.youtube.com",
+    "user-agent": "your_user_agent_here",
+    "x-goog-authuser": "0",
+    "x-youtube-client-name": "67",
+    "x-youtube-client-version": "your_client_version_here"
+}

--- a/Spotify to YtMusic/creds.json
+++ b/Spotify to YtMusic/creds.json
@@ -1,0 +1,6 @@
+{
+  "SPOTIPY_CLIENT_ID": "your_spotify_client_id_here",
+  "SPOTIPY_CLIENT_SECRET": "your_spotify_client_secret_here",
+  "SPOTIPY_REDIRECT_URI": "http://127.0.0.1:8888/callback",
+  "SCOPE": "user-library-read playlist-read-private"
+}

--- a/Spotify to YtMusic/main.py
+++ b/Spotify to YtMusic/main.py
@@ -1,0 +1,128 @@
+import os
+import json
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+from ytmusicapi import YTMusic
+
+
+def load_creds(path="creds.json"):
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Missing {path}")
+    with open(path, "r") as file:
+        return json.load(file)
+
+
+def init_spotify(creds):
+    CACHE_PATH = '.spotify_cache'
+    auth_manager = SpotifyOAuth(
+        client_id=creds["SPOTIPY_CLIENT_ID"],
+        client_secret=creds["SPOTIPY_CLIENT_SECRET"],
+        redirect_uri=creds["SPOTIPY_REDIRECT_URI"],
+        scope=creds["SCOPE"],
+        cache_path=CACHE_PATH,
+        open_browser=False
+    )
+    return spotipy.Spotify(auth_manager=auth_manager)
+
+
+def init_ytmusic():
+    if not os.path.exists("browser.json"):
+        raise FileNotFoundError("Missing browser.json for YTMusic authentication.")
+    return YTMusic("browser.json")
+
+
+def list_playlists(sp):
+    playlists = []
+    results = sp.current_user_playlists()
+    while results:
+        playlists.extend(results['items'])
+        results = sp.next(results) if results['next'] else None
+    return playlists
+
+
+def select_playlist(playlists):
+    print("\nFetching Spotify playlists...")
+    for i, playlist in enumerate(playlists, start=1):
+        print(f"{i}. {playlist['name']} ({playlist['tracks']['total']} tracks)")
+    while True:
+        try:
+            choice = int(input("\nEnter the playlist number: "))
+            if 1 <= choice <= len(playlists):
+                return playlists[choice - 1]
+        except ValueError:
+            pass
+        print("Invalid input. Try again.")
+
+
+def fetch_tracks(sp, playlist_id):
+    print("Fetching tracks from playlist...")
+    tracks = []
+    results = sp.playlist_items(playlist_id)
+    while results:
+        tracks.extend(results['items'])
+        results = sp.next(results) if results['next'] else None
+    return [
+        {
+            'name': i['track']['name'],
+            'artist': i['track']['artists'][0]['name']
+        }
+        for i in tracks if i.get('track')
+    ]
+
+
+def search_yt_song(ytmusic, name, artist):
+    query = f"{name} {artist}"
+    try:
+        results = ytmusic.search(query, filter="songs")
+        return results[0]['videoId'] if results else None
+    except Exception as e:
+        print(f"Error searching '{query}': {e}")
+        return None
+
+
+def create_yt_playlist(ytmusic, title, description, video_ids):
+    try:
+        playlist_id = ytmusic.create_playlist(title=title, description=description, video_ids=video_ids)
+        return f"https://music.youtube.com/playlist?list={playlist_id}"
+    except Exception as e:
+        print(f"Error creating YouTube playlist: {e}")
+        return None
+
+
+def main():
+    print("Loading credentials...")
+    creds = load_creds()
+
+    print("Authenticating Spotify and YouTube Music...\n")
+    sp = init_spotify(creds)
+    ytmusic = init_ytmusic()
+
+    playlists = list_playlists(sp)
+    selected = select_playlist(playlists)
+    print(f"Selected playlist: {selected['name']}")
+
+    tracks = fetch_tracks(sp, selected['id'])
+    print(f"Found {len(tracks)} tracks.")
+
+    video_ids = []
+    for idx, track in enumerate(tracks, start=1):
+        print(f"[{idx}/{len(tracks)}] Searching '{track['name']} - {track['artist']}'")
+        video_id = search_yt_song(ytmusic, track['name'], track['artist'])
+        if video_id:
+            video_ids.append(video_id)
+        else:
+            print(f"No match found for '{track['name']}'")
+
+    if not video_ids:
+        print("No songs found on YouTube Music. Exiting.")
+        return
+
+    playlist_url = create_yt_playlist(ytmusic, selected['name'], "Transferred from Spotify", video_ids)
+    if playlist_url:
+        print(f"✅ Playlist created successfully: {playlist_url}")
+    else:
+        print("Failed to create YouTube playlist.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Spotify to YtMusic/readme.md
+++ b/Spotify to YtMusic/readme.md
@@ -1,0 +1,115 @@
+# Spotify to YtMusic
+
+A simple Python tool to transfer your Spotify playlists to YouTube Music.
+
+---
+
+## Features
+
+* List all your Spotify playlists.
+* Select a playlist to transfer.
+* Search songs on YouTube Music.
+* Create a new YouTube Music playlist with the matched songs.
+
+---
+
+## Requirements
+
+* Python 3.10+
+* `spotipy`
+* `ytmusicapi`
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## Setup
+
+### 1. Create `creds.json`
+
+Create a file named `creds.json` in the project root with your Spotify API credentials:
+
+```json
+{
+    "SPOTIPY_CLIENT_ID": "your_spotify_client_id_here",
+    "SPOTIPY_CLIENT_SECRET": "your_spotify_client_secret_here",
+    "SPOTIPY_REDIRECT_URI": "http://127.0.0.1:8888/callback",
+    "SCOPE": "user-library-read playlist-read-private"
+}
+```
+
+Get your Spotify API credentials from the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/).
+
+### 2. Create `browser.json` for YouTube Music
+
+`ytmusicapi` uses `browser.json` for authentication. You can generate it automatically or manually.
+
+#### Automatic method:
+
+```bash
+ytmusicapi browser
+```
+
+#### Manual example of `browser.json`:
+
+```json
+{
+    "accept": "*/*",
+    "accept-encoding": "gzip, deflate",
+    "authorization": "your_authorization_token_here",
+    "content-encoding": "gzip",
+    "content-type": "application/json",
+    "cookie": "your_cookie_data_here",
+    "origin": "https://music.youtube.com",
+    "user-agent": "your_user_agent_here",
+    "x-goog-authuser": "0",
+    "x-youtube-client-name": "67",
+    "x-youtube-client-version": "your_client_version_here"
+}
+```
+
+For full instructions, check [ytmusicapi documentation](https://ytmusicapi.readthedocs.io/en/latest/setup.html).
+
+### 4. Run the tool
+
+```bash
+python main.py
+```
+
+Follow the prompts to select your Spotify playlist and transfer it to YouTube Music.
+
+---
+
+## File Structure
+
+```
+Spotify-to-YtMusic/
+│
+├── browser.json        # YouTube Music authentication
+├── creds.json          # Spotify API credentials
+├── main.py             # Main Python script
+├── requirements.txt    # Project dependencies
+├── readme.md           # Project documentation
+```
+
+---
+
+### requirements.txt
+
+```
+spotipy==2.23.0
+ytmusicapi==0.21.0
+```
+
+---
+
+### Notes
+
+* Ensure both `creds.json` and `browser.json` are in the same directory as `main.py`.
+* You need a valid Spotify Developer account and YouTube Music authentication to use this tool.
+
+**Now you can easily run this project and transfer playlists from Spotify to YouTube Music.**

--- a/Spotify to YtMusic/requirements.txt
+++ b/Spotify to YtMusic/requirements.txt
@@ -1,0 +1,2 @@
+spotipy==2.23.0
+ytmusicapi==0.21.0


### PR DESCRIPTION
## Description
This PR adds a small Python project called **"Spotify to YTMusic"** that allows users to transfer playlists from Spotify to YouTube Music easily.  
It fetches all tracks from a Spotify playlist and searches them on YouTube Music, then creates a new YouTube Music playlist with those tracks.

## Features
- Authenticate with Spotify using OAuth credentials stored in a `creds.json` file.
- Authenticate with YouTube Music using `browser.json`.
- List all Spotify playlists for the user.
- Select a playlist and transfer its tracks to YouTube Music.
- Outputs the YouTube Music playlist link upon success.

## Why This Should Be Merged
This project:
- Solves a common problem for users switching between Spotify and YouTube Music.
- Is lightweight and easy to run.
- Uses minimal dependencies.
- Comes with clear instructions for setup and usage.

## Setup Instructions
1. Clone the repo.
2. Install dependencies:
   ```bash
   pip install -r requirements.txt
3. Add your Spotify credentials to creds.json.
4. Add your YouTube Music authentication in browser.json.
5. Run:
   ```bash
   python main.py

## Files Added
- `main.py`— Main script for playlist transfer.
- `creds.json` — Spotify credentials (excluded from repo, sample provided).
- `requirements.txt` — Dependencies list.
- `readme.md` — Project instructions and details.

## Additional Notes
- This is a simple but useful utility for music lovers and can be extended with:
- Support for multiple playlist transfers.
- Advanced matching algorithms for better track matching.
- GUI for easier usage.